### PR TITLE
fix: Register driver post initialization

### DIFF
--- a/VRCFTReceiver/VRCFTReceiver.cs
+++ b/VRCFTReceiver/VRCFTReceiver.cs
@@ -38,7 +38,15 @@ namespace VRCFTReceiver
 				Harmony harmony = new Harmony("dev.hazre.VRCFTReceiver");
 				harmony.PatchAll();
 
-				TryDirectDriverInitialization();
+				var engine = Engine.Current;
+				if (engine != null)
+				{
+					engine.RunPostInit(RegisterDriver);
+				}
+				else
+				{
+					UniLog.Error($"[VRCFTReceiver] OnEngineInit failed: Engine.Current is null");
+				}
 			}
 			catch (Exception ex)
 			{
@@ -59,17 +67,21 @@ namespace VRCFTReceiver
 			}
 		}
 
-		private static void TryDirectDriverInitialization()
+		private static void RegisterDriver()
 		{
 			try
 			{
 				var engine = Engine.Current;
 
-				if (engine?.InputInterface != null && VRCFTDriver == null)
+				if (engine.InputInterface != null)
 				{
 					VRCFTDriver = new Driver();
 					engine.InputInterface.RegisterInputDriver(VRCFTDriver);
 					UniLog.Log("[VRCFTReceiver] Driver initialized successfully");
+				}
+				else
+				{
+					UniLog.Error($"[VRCFTReceiver] RegisterDriver failed: Engine.InputInterface is null");
 				}
 			}
 			catch (Exception ex)

--- a/VRCFTReceiver/VRCFTReceiver.cs
+++ b/VRCFTReceiver/VRCFTReceiver.cs
@@ -41,7 +41,7 @@ namespace VRCFTReceiver
 				var engine = Engine.Current;
 				if (engine != null)
 				{
-					engine.RunPostInit(RegisterDriver);
+					engine.RunPostInit(() => RegisterDriver(engine));
 				}
 				else
 				{
@@ -67,12 +67,10 @@ namespace VRCFTReceiver
 			}
 		}
 
-		private static void RegisterDriver()
+		private static void RegisterDriver(Engine engine)
 		{
 			try
 			{
-				var engine = Engine.Current;
-
 				if (engine.InputInterface != null)
 				{
 					VRCFTDriver = new Driver();

--- a/VRCFTReceiver/VRCFTReceiver.csproj
+++ b/VRCFTReceiver/VRCFTReceiver.csproj
@@ -19,6 +19,7 @@
 		<CopyToMods Condition="'$(CopyToMods)'==''">true</CopyToMods>
 		<DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>
 		<DebugType Condition="'$(Configuration)'=='Release'">None</DebugType>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -91,11 +92,4 @@
 		<Message Text="Copied MeaMod.DNS.dll to $(GamePath)rml_libs" Importance="high" Condition="Exists('$(TargetDir)MeaMod.DNS.dll')" />
 		<Message Text="Warning: MeaMod.DNS.dll not found in $(TargetDir)" Importance="high" Condition="!Exists('$(TargetDir)MeaMod.DNS.dll')" />
 	</Target>
-
-	<ItemGroup>
-		<Reference Update="@(Reference)">
-			<Private>false</Private>
-			<PrivateAssets>all</PrivateAssets>
-		</Reference>
-	</ItemGroup>
 </Project>


### PR DESCRIPTION
On my machine (Resonite 2025.6.17.855, ResoniteModLoader 3.0.0), VRCFTReceiver would be loaded by ResoniteModLoader immediately before Resonite initialized the input interface. This caused the driver initialization function to silently fail.

This fix defers driver initialization until after Resonite is fully initialized. The [ResoniteModLoader wiki](https://github.com/resonite-modding-group/ResoniteModLoader/wiki/Creating-Mods#runpostinit) states that the input device setup occurs after `OnEngineInit` and that `Engine.RunPostInit` should be used to register a callback instead.

This change also improves error logging during startup for other unexpected null conditions within FrooxEngine.Engine.

With this fix I was able to get blinking working, but not full eye tracking yet. 